### PR TITLE
If settings exist for current user need response param "is_empty" = FALS...

### DIFF
--- a/notices.module
+++ b/notices.module
@@ -396,7 +396,7 @@ function notices_load_settings($uid) {
         }
       }
 
-      $settings->is_empty = TRUE;
+      $settings->is_empty = FALSE;
     }
   }
   else {


### PR DESCRIPTION
If settings exist for current user need response param "is_empty" = FALSE. And settings not create double.
